### PR TITLE
Add first version of batch mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -395,10 +395,10 @@ def edit_token(session: mwapi.Session) -> str:
     return token
 
 
-def save_entity_and_redirect(entity_data: dict,
-                             summary: str,
-                             base_revision_id: int,
-                             session: mwapi.Session) -> werkzeug.Response:
+def save_entity(entity_data: dict,
+                summary: str,
+                base_revision_id: int,
+                session: mwapi.Session) -> int:
 
     token = edit_token(session)
 
@@ -409,6 +409,19 @@ def save_entity_and_redirect(entity_data: dict,
                                 baserevid=base_revision_id,
                                 token=token)
     revision_id = api_response['entity']['lastrevid']
+
+    return revision_id
+
+
+def save_entity_and_redirect(entity_data: dict,
+                             summary: str,
+                             base_revision_id: int,
+                             session: mwapi.Session) -> werkzeug.Response:
+
+    revision_id = save_entity(entity_data,
+                              summary,
+                              base_revision_id,
+                              session)
 
     return flask.redirect(f'{session.host}/w/index.php'
                           f'?diff={revision_id}&oldid={base_revision_id}')

--- a/app.py
+++ b/app.py
@@ -248,12 +248,8 @@ def edit_increment_rank(wiki: str, entity_id: str, property_id: str) \
                 edited_statements += 1
 
     edited_entity = build_entity(entity_id, {property_id: statements})
-    if edited_statements == 1:
-        summary = 'Incremented rank of 1 statement'
-    else:
-        summary = f'Incremented rank of {edited_statements} statements'
-    if flask.request.form.get('summary'):
-        summary += ': ' + flask.request.form['summary']
+    summary = get_summary_increment_rank(edited_statements,
+                                         flask.request.form.get('summary'))
 
     return save_entity_and_redirect(edited_entity,
                                     summary,
@@ -479,6 +475,17 @@ def get_summary_set_rank(edited_statements: int,
         summary = f'Set rank of 1 statement to {rank}'
     else:
         summary = f'Set rank of {edited_statements} statements to {rank}'
+    if custom_summary is not None:
+        summary += ': ' + custom_summary
+    return summary
+
+
+def get_summary_increment_rank(edited_statements: int,
+                               custom_summary: Optional[str]) -> str:
+    if edited_statements == 1:
+        summary = 'Incremented rank of 1 statement'
+    else:
+        summary = f'Incremented rank of {edited_statements} statements'
     if custom_summary is not None:
         summary += ': ' + custom_summary
     return summary

--- a/app.py
+++ b/app.py
@@ -309,6 +309,8 @@ def batch_list_set_rank(wiki: str, rank: str) \
             print('caught error in batch mode:', e, file=sys.stderr)
             errors[entity_id] = e
 
+    wbformat.prefetch_entities(session, statement_ids_by_entity_id.keys())
+
     return flask.render_template('batch-results.html',
                                  wiki=wiki,
                                  edits=edits,

--- a/app.py
+++ b/app.py
@@ -209,12 +209,9 @@ def edit_set_rank(wiki: str, entity_id: str, property_id: str, rank: str) \
     )
 
     edited_entity = build_entity(entity_id, statement_groups)
-    if edited_statements == 1:
-        summary = f'Set rank of 1 statement to "{rank}"'
-    else:
-        summary = f'Set rank of {edited_statements} statements to "{rank}"'
-    if flask.request.form.get('summary'):
-        summary += ': ' + flask.request.form['summary']
+    summary = get_summary_set_rank(edited_statements,
+                                   rank,
+                                   flask.request.form.get('summary'))
 
     return save_entity_and_redirect(edited_entity,
                                     summary,
@@ -410,6 +407,18 @@ def build_entity(entity_id: str,
         'claims': statement_groups,
         # yes, 'claims' even for MediaInfo entities
     }
+
+
+def get_summary_set_rank(edited_statements: int,
+                         rank: str,
+                         custom_summary: Optional[str]) -> str:
+    if edited_statements == 1:
+        summary = f'Set rank of 1 statement to {rank}'
+    else:
+        summary = f'Set rank of {edited_statements} statements to {rank}'
+    if custom_summary is not None:
+        summary += ': ' + custom_summary
+    return summary
 
 
 def edit_token(session: mwapi.Session) -> str:

--- a/app.py
+++ b/app.py
@@ -207,7 +207,7 @@ def edit_set_rank(wiki: str, entity_id: str, property_id: str, rank: str) \
             statement['rank'] = rank
             edited_statements += 1
 
-    edited_entity = build_entity(entity_id, property_id, statements)
+    edited_entity = build_entity(entity_id, {property_id: statements})
     if edited_statements == 1:
         summary = f'Set rank of 1 statement to "{rank}"'
     else:
@@ -248,7 +248,7 @@ def edit_increment_rank(wiki: str, entity_id: str, property_id: str) \
                 statement['rank'] = incremented_rank
                 edited_statements += 1
 
-    edited_entity = build_entity(entity_id, property_id, statements)
+    edited_entity = build_entity(entity_id, {property_id: statements})
     if edited_statements == 1:
         summary = 'Incremented rank of 1 statement'
     else:
@@ -375,13 +375,11 @@ def increment_rank(rank: str) -> str:
 
 
 def build_entity(entity_id: str,
-                 property_id: str,
-                 statements: List[dict]) -> dict:
+                 statement_groups: Dict[str, List[dict]]) -> dict:
     return {
         'id': entity_id,
-        'claims': {  # yes, 'claims' even for MediaInfo entities
-            property_id: statements,
-        },
+        'claims': statement_groups,
+        # yes, 'claims' even for MediaInfo entities
     }
 
 

--- a/app.py
+++ b/app.py
@@ -279,12 +279,8 @@ def batch_list_set_rank(wiki: str, rank: str) \
     session = authenticated_session(wiki)
     assert session is not None
 
-    statement_ids = flask.request.form.get('statement_ids', '').splitlines()
-    statement_ids_by_entity_id: Dict[str, List[str]] = {}
-    for statement_id in statement_ids:
-        entity_id = statement_id.split('$', 1)[0].upper()
-        statement_ids_by_entity_id.setdefault(entity_id, [])\
-                                  .append(statement_id)
+    statement_ids_by_entity_id = parse_statement_ids_list(
+        flask.request.form.get('statement_ids', ''))
 
     entities = get_entities(session, statement_ids_by_entity_id.keys())
     edits = {}
@@ -397,6 +393,16 @@ def deny_frame(response: flask.Response) -> flask.Response:
     """
     response.headers['X-Frame-Options'] = 'deny'
     return response
+
+
+def parse_statement_ids_list(input: str) -> Dict[str, List[str]]:
+    statement_ids = input.splitlines()
+    statement_ids_by_entity_id: Dict[str, List[str]] = {}
+    for statement_id in statement_ids:
+        entity_id = statement_id.split('$', 1)[0].upper()
+        statement_ids_by_entity_id.setdefault(entity_id, [])\
+                                  .append(statement_id)
+    return statement_ids_by_entity_id
 
 
 def get_entities(session: mwapi.Session, entity_ids: Iterable[str]) -> dict:

--- a/app.py
+++ b/app.py
@@ -570,7 +570,7 @@ def edit_token(session: mwapi.Session) -> str:
     Not to be confused with csrf_token,
     which gets a token for use within the tool."""
 
-    edit_tokens = flask.g.setdefault('edit_tokens', {})
+    edit_tokens = flask.g.setdefault('edit_tokens', {})  # type: ignore
     key = session.host
     if key in edit_tokens:
         return edit_tokens[key]

--- a/templates/batch-list-collective.html
+++ b/templates/batch-list-collective.html
@@ -48,7 +48,6 @@
     {{ disabled_attrs }}>
     Set to deprecated rank
   </button>
-  {#
   <button
     type="submit"
     class="btn btn-secondary"
@@ -56,6 +55,5 @@
     {{ disabled_attrs }}>
     Increment rank
   </button>
-  #}
 </form>
 {% endblock %}

--- a/templates/batch-list-collective.html
+++ b/templates/batch-list-collective.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block main %}
+{% if not can_edit() %}
+<div class="alert alert-warning" role="alert">
+  You must <a href="{{ url_for('login') }}">log in</a> to make edits.
+</div>
+{% endif %}
+<form method="post">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <div class="form-group">
+    <label for="statement_ids">Statement IDs (one per line):</label>
+    <textarea
+      class="form-control"
+      id="statement_ids"
+      name="statement_ids"
+      placeholder="Q474472$dcf39f47-4275-6529-96f5-94808c2a81ac&#xa;Q3841190$dbcf6be8-41c0-5955-d618-2d06ab241344"
+      required
+      rows="10"
+      ></textarea>
+  </div>
+  <div class="form-group">
+    <label for="summary">Edit summary (optional):</label>
+    <input name="summary" type="text" id="summary" class="form-control">
+  </div>
+  {% if can_edit() %}
+  {% set disabled_attrs = '' %}
+  {% else %}
+  {% set disabled_attrs = 'disabled title="You must log in to make edits."' | safe %}
+  {% endif %}
+  <button
+    type="submit"
+    class="btn btn-primary"
+    formaction="{{ url_for('batch_list_set_rank', wiki=wiki, rank='preferred') }}"
+    {{ disabled_attrs }}>
+    Set to preferred rank
+  </button>
+  <button
+    type="submit"
+    class="btn btn-secondary"
+    formaction="{{ url_for('batch_list_set_rank', wiki=wiki, rank='normal') }}"
+    {{ disabled_attrs }}>
+    Set to normal rank
+  </button>
+  <button
+    type="submit"
+    class="btn btn-secondary"
+    formaction="{{ url_for('batch_list_set_rank', wiki=wiki, rank='deprecated') }}"
+    {{ disabled_attrs }}>
+    Set to deprecated rank
+  </button>
+  {#
+  <button
+    type="submit"
+    class="btn btn-secondary"
+    formaction="{{ url_for('batch_list_increment_rank', wiki=wiki) }}"
+    {{ disabled_attrs }}>
+    Increment rank
+  </button>
+  #}
+</form>
+{% endblock %}

--- a/templates/batch-results.html
+++ b/templates/batch-results.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block main %}
+{% if edits %}
+<p>
+  The following entities were successfully edited:
+</p>
+<ul>
+  {% for entity_id, revision_id in edits.items() %}
+  <li>
+    {{ format_entity(wiki, entity_id) }}
+    (<a href="https://{{ wiki }}/w/index.php?diff={{ revision_id }}">diff</a>)
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% if errors %}
+<p>
+  The following entities could not be edited due to errors:
+</p>
+<ul>
+  {% for entity_id, error in errors.items() %}
+  <li>
+    {{ format_entity(wiki, entity_id) }}
+    ({{ error.info }})
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/test_app.py
+++ b/test_app.py
@@ -59,6 +59,17 @@ def test_format_value_escapes_html():
     assert ranker.format_value('test.wikidata.org', 'P95', value) == expected
 
 
+def test_get_entities():
+    class FakeSession:
+        def get(self, ids, **kwargs):
+            assert len(ids) <= 50
+            return {'entities': {id: f'entity {id}' for id in ids}}
+
+    entity_ids = [f'Q{id}' for id in range(1, 120)]
+    entities = ranker.get_entities(FakeSession(), entity_ids)
+    assert entities == {id: f'entity {id}' for id in entity_ids}
+
+
 @pytest.mark.parametrize('rank, expected', [
     ('deprecated', 'normal'),
     ('normal', 'preferred'),

--- a/wbformat.py
+++ b/wbformat.py
@@ -3,7 +3,7 @@ import flask
 import json
 import mwapi  # type: ignore
 import threading
-from typing import List, Set, Tuple
+from typing import AbstractSet, List, Tuple
 
 
 def format_value(session: mwapi.Session,
@@ -38,7 +38,7 @@ def format_entity(session: mwapi.Session,
 
 
 def prefetch_entities(session: mwapi.Session,
-                      entity_ids: Set[str]):
+                      entity_ids: AbstractSet[str]):
     with format_entity_cache_lock:
         entity_id_chunks: List[List[str]] = []
         for entity_id in entity_ids:


### PR DESCRIPTION
I’m envisioning four versions of batch mode, differing in two dimensions: the input can be a plain text **list** of statement IDs, or a **SPARQL** query; and it **collective**ly edits the rank of each statement in the same way (set or increment), or allows setting a custom rank for each **individual** statement. This implements the first combination: setting or incrementing the rank of a plain text list of statement IDs, using the same collective action for all statements. Other combinations will follow.

Many refactorings are included as separate commits; the actual batch mode actions are then fairly straightforward at the end.