### PR TITLE
Add batch mode to edit rank of statements

### DIFF
--- a/app.py
+++ b/app.py
@@ -430,11 +430,15 @@ def deny_frame(response: flask.Response) -> flask.Response:
     return response
 
 
+def entity_id_from_statement_id(statement_id: str) -> str:
+    return statement_id.split('$', 1)[0].upper()
+
+
 def parse_statement_ids_list(input: str) -> Dict[str, List[str]]:
     statement_ids = input.splitlines()
     statement_ids_by_entity_id: Dict[str, List[str]] = {}
     for statement_id in statement_ids:
-        entity_id = statement_id.split('$', 1)[0].upper()
+        entity_id = entity_id_from_statement_id(statement_id)
         statement_ids_by_entity_id.setdefault(entity_id, [])\
                                   .append(statement_id)
     return statement_ids_by_entity_id

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import mwapi  # type: ignore
 import mwoauth  # type: ignore
 import os
 import random
+import re
 import requests
 import requests_oauthlib  # type: ignore
 import string
@@ -348,6 +349,54 @@ def batch_list_increment_rank(wiki: str) \
                                  errors=errors)
 
 
+@app.route('/batch/list/individual/<wiki:wiki>/')
+def show_batch_list_individual_form(wiki: str) -> str:
+    return flask.render_template('batch-list-individual.html',
+                                 wiki=wiki)
+
+
+@app.route('/batch/list/individual/<wiki:wiki>/',
+           methods=['POST'])
+def batch_list_edit_rank(wiki: str) -> Union[str, Tuple[str, int]]:
+    if not submitted_request_valid():
+        return 'CSRF error', 400  # TODO better error
+
+    session = authenticated_session(wiki)
+    if session is None:
+        return 'not logged in', 401  # TODO better error
+
+    commands_by_entity_id = parse_statement_ids_with_ranks(
+        flask.request.form.get('commands', ''))
+
+    entities = get_entities(session, commands_by_entity_id.keys())
+    edits = {}
+    errors = {}
+
+    for entity_id, commands in commands_by_entity_id.items():
+        entity = entities[entity_id]
+        statements = entity_statements(entity)
+        statements, edited_statements = statements_edit_rank(commands,
+                                                             statements)
+        edited_entity = build_entity(entity_id, statements)
+        summary = get_summary_edit_rank(edited_statements,
+                                        flask.request.form.get('summary'))
+        try:
+            edits[entity_id] = save_entity(edited_entity,
+                                           summary,
+                                           entity['lastrevid'],
+                                           session)
+        except mwapi.errors.APIError as e:
+            print('caught error in batch mode:', e, file=sys.stderr)
+            errors[entity_id] = e
+
+    wbformat.prefetch_entities(session, commands_by_entity_id.keys())
+
+    return flask.render_template('batch-results.html',
+                                 wiki=wiki,
+                                 edits=edits,
+                                 errors=errors)
+
+
 @app.route('/login')
 def login() -> werkzeug.Response:
     redirect, request_token = mwoauth.initiate(index_php,
@@ -444,6 +493,17 @@ def parse_statement_ids_list(input: str) -> Dict[str, List[str]]:
     return statement_ids_by_entity_id
 
 
+def parse_statement_ids_with_ranks(input: str) \
+        -> Dict[str, Dict[str, str]]:
+    commands = input.splitlines()
+    commands_by_entity_id: Dict[str, Dict[str, str]] = {}
+    for command in commands:
+        statement_id, rank = re.split('[|\t]', command, maxsplit=1)
+        entity_id = entity_id_from_statement_id(statement_id)
+        commands_by_entity_id.setdefault(entity_id, {})[statement_id] = rank
+    return commands_by_entity_id
+
+
 def get_entities(session: mwapi.Session, entity_ids: Iterable[str]) -> dict:
     entity_ids = list(set(entity_ids))
     entities = {}
@@ -532,6 +592,20 @@ def statements_increment_rank(statement_ids: Container[str],
     return statement_groups, edited_statements
 
 
+def statements_edit_rank(commands: Dict[str, str],
+                         statements: Dict[str, List[dict]]) \
+        -> Tuple[Dict[str, List[dict]], int]:
+    edited_statements = 0
+    for statement_group in statements.values():
+        for statement in statement_group:
+            if statement['id'] in commands:
+                edited_rank = commands[statement['id']]
+                if edited_rank != statement['rank']:
+                    statement['rank'] = edited_rank
+                    edited_statements += 1
+    return statements, edited_statements
+
+
 def build_entity(entity_id: str,
                  statement_groups: Dict[str, List[dict]]) -> dict:
     return {
@@ -559,6 +633,17 @@ def get_summary_increment_rank(edited_statements: int,
         summary = 'Incremented rank of 1 statement'
     else:
         summary = f'Incremented rank of {edited_statements} statements'
+    if custom_summary is not None:
+        summary += ': ' + custom_summary
+    return summary
+
+
+def get_summary_edit_rank(edited_statements: int,
+                          custom_summary: Optional[str]) -> str:
+    if edited_statements == 1:
+        summary = 'Edited rank of 1 statement'
+    else:
+        summary = f'Edited rank of {edited_statements} statements'
     if custom_summary is not None:
         summary += ': ' + custom_summary
     return summary

--- a/templates/batch-list-individual.html
+++ b/templates/batch-list-individual.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block main %}
+{% if not can_edit() %}
+<div class="alert alert-warning" role="alert">
+  You must <a href="{{ url_for('login') }}">log in</a> to make edits.
+</div>
+{% endif %}
+<form method="post">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <div class="form-group">
+    <label for="commands">Statement IDs and ranks (one per line, separated by tab or pipe characters):</label>
+    <textarea
+      class="form-control"
+      id="commands"
+      name="commands"
+      placeholder="Q474472$dcf39f47-4275-6529-96f5-94808c2a81ac|normal&#xa;Q3841190$dbcf6be8-41c0-5955-d618-2d06ab241344|preferred&#xa;Q843864$27BF8D25-B1A9-4488-94BF-9564EE2A5776|deprecated"
+      required
+      rows="10"
+      ></textarea>
+  </div>
+  <div class="form-group">
+    <label for="summary">Edit summary (optional):</label>
+    <input name="summary" type="text" id="summary" class="form-control">
+  </div>
+  <button
+    type="submit"
+    class="btn btn-primary"
+    formaction="{{ url_for('batch_list_edit_rank', wiki=wiki) }}"
+    {% if not can_edit() %}
+    disabled
+    title="You must log in to make edits."
+    {% endif %}
+    >
+    Edit rank of statements
+  </button>
+</form>
+{% endblock %}

--- a/test_app.py
+++ b/test_app.py
@@ -85,6 +85,21 @@ P3$123
     }
 
 
+def test_parse_statement_ids_with_ranks():
+    input = '''
+Q1$123|normal
+Q2$123|deprecated
+Q1$456\tpreferred
+q2$456\tnormal
+P3$123|preferred
+'''.strip()
+    assert ranker.parse_statement_ids_with_ranks(input) == {
+        'Q1': {'Q1$123': 'normal', 'Q1$456': 'preferred'},
+        'Q2': {'Q2$123': 'deprecated', 'q2$456': 'normal'},
+        'P3': {'P3$123': 'preferred'},
+    }
+
+
 def test_get_entities():
     class FakeSession:
         def get(self, ids, **kwargs):
@@ -198,6 +213,32 @@ def test_statements_increment_rank(with_property_id: bool):
     assert unrelated_statement['rank'] == 'normal'
 
 
+def test_statements_edit_rank():
+    unselected_statement = {'id': 'Y', 'rank': 'normal'}
+    unedited_statement = {'id': 'a', 'rank': 'preferred'}
+    edited_statement = {'id': 'b', 'rank': 'normal'}
+    commands = {'a': 'preferred', 'b': 'preferred'}
+    statements = {
+        'P1': [
+            unselected_statement,
+            unedited_statement,
+            edited_statement,
+        ],
+    }
+
+    statements, edited_statements = ranker.statements_edit_rank(
+        commands,
+        statements,
+    )
+
+    assert edited_statements == 1
+    assert 'P1' in statements
+    assert edited_statement in statements['P1']
+    assert edited_statement['rank'] == 'preferred'
+    assert unedited_statement['rank'] == 'preferred'
+    assert unselected_statement['rank'] == 'normal'
+
+
 @pytest.mark.parametrize('edited_statements, rank, custom_summary, expected', [
     (1, 'preferred', None, 'Set rank of 1 statement to preferred'),
     (2, 'deprecated', None, 'Set rank of 2 statements to deprecated'),
@@ -221,3 +262,14 @@ def test_get_summary_increment_rank(edited_statements: int,
                                     expected: str):
     assert expected == ranker.get_summary_increment_rank(edited_statements,
                                                          custom_summary)
+
+
+@pytest.mark.parametrize('edited_statements, custom_summary, expected', [
+    (1, None, 'Edited rank of 1 statement'),
+    (2, 'custom', 'Edited rank of 2 statements: custom'),
+])
+def test_get_summary_edit_rank(edited_statements: int,
+                               custom_summary: Optional[str],
+                               expected: str):
+    assert expected == ranker.get_summary_edit_rank(edited_statements,
+                                                    custom_summary)

--- a/test_app.py
+++ b/test_app.py
@@ -60,6 +60,15 @@ def test_format_value_escapes_html():
     assert ranker.format_value('test.wikidata.org', 'P95', value) == expected
 
 
+@pytest.mark.parametrize('statement_id, entity_id', [
+    ('Q1$123', 'Q1'),
+    ('p1$123', 'P1'),
+    ('L1-S1$123', 'L1-S1'),
+])
+def test_entity_id_from_statement_id(statement_id: str, entity_id: str):
+    assert ranker.entity_id_from_statement_id(statement_id) == entity_id
+
+
 def test_parse_statement_ids_list():
     input = '''
 Q1$123


### PR DESCRIPTION
This version of batch mode lets users specify a rank for each individual listed statement, and is therefore more flexible than the previous “collective” batch mode (#1).