### PR TITLE
Add query-based collective batch mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -319,6 +319,57 @@ def batch_list_increment_rank(wiki: str) \
                                                  custom_summary)
 
 
+@app.route('/batch/query/collective/<wwqs:wiki>/')
+def show_batch_query_collective_form(wiki: str) -> str:
+    return flask.render_template('batch-query-collective.html',
+                                 wiki=wiki)
+
+
+@app.route('/batch/query/collective/<wwqs:wiki>/set/<rank:rank>',
+           methods=['POST'])
+def batch_query_set_rank(wiki: str, rank: str) \
+        -> Union[str, Tuple[str, int]]:
+    if not submitted_request_valid():
+        return 'CSRF error', 400  # TODO better error
+
+    session = authenticated_session(wiki)
+    if session is None:
+        return 'not logged in', 401  # TODO better error
+
+    query = flask.request.form.get('query', '')
+    custom_summary = flask.request.form.get('summary')
+
+    statement_ids_by_entity_id = query_statement_ids(wiki, query)
+
+    return batch_set_rank_and_show_results(wiki,
+                                           statement_ids_by_entity_id,
+                                           rank,
+                                           session,
+                                           custom_summary)
+
+
+@app.route('/batch/query/collective/<wwqs:wiki>/increment',
+           methods=['POST'])
+def batch_query_increment_rank(wiki: str) \
+        -> Union[str, Tuple[str, int]]:
+    if not submitted_request_valid():
+        return 'CSRF error', 400  # TODO better error
+
+    session = authenticated_session(wiki)
+    if session is None:
+        return 'not logged in', 401  # TODO better error
+
+    query = flask.request.form.get('query', '')
+    custom_summary = flask.request.form.get('summary')
+
+    statement_ids_by_entity_id = query_statement_ids(wiki, query)
+
+    return batch_increment_rank_and_show_results(wiki,
+                                                 statement_ids_by_entity_id,
+                                                 session,
+                                                 custom_summary)
+
+
 @app.route('/batch/list/individual/<wiki:wiki>/')
 def show_batch_list_individual_form(wiki: str) -> str:
     return flask.render_template('batch-list-individual.html',

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ import yaml
 
 from converters import EntityIdConverter, PropertyIdConverter, \
     RankConverter, WikiConverter, WikiWithQueryServiceConverter
-from query_service import query_service_name, query_service_url
+from query_service import query_wiki, query_service_name, query_service_url
 import wbformat
 
 
@@ -470,6 +470,21 @@ def parse_statement_ids_list(input: str) -> Dict[str, List[str]]:
     statement_ids = input.splitlines()
     statement_ids_by_entity_id: Dict[str, List[str]] = {}
     for statement_id in statement_ids:
+        entity_id = entity_id_from_statement_id(statement_id)
+        statement_ids_by_entity_id.setdefault(entity_id, [])\
+                                  .append(statement_id)
+    return statement_ids_by_entity_id
+
+
+def query_statement_ids(wiki: str, query: str) -> Dict[str, List[str]]:
+    results = query_wiki(wiki, query, user_agent)
+    assert 'statement' in results['head']['vars']  # TODO better error handling
+    statement_ids_by_entity_id: Dict[str, List[str]] = {}
+    for result in results['results']['bindings']:
+        if result['statement']['type'] != 'uri':
+            continue
+        statement_id = statement_id_from_uri(result['statement']['value'],
+                                             wiki)
         entity_id = entity_id_from_statement_id(statement_id)
         statement_ids_by_entity_id.setdefault(entity_id, [])\
                                   .append(statement_id)

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ import yaml
 
 from converters import EntityIdConverter, PropertyIdConverter, \
     RankConverter, WikiConverter
+from query_service import query_service_name, query_service_url
 import wbformat
 
 
@@ -110,6 +111,15 @@ def format_value(wiki: str, property_id: str, value: dict) -> flask.Markup:
 @app.template_global()
 def format_entity(wiki: str, entity_id: str) -> flask.Markup:
     return wbformat.format_entity(anonymous_session(wiki), entity_id)
+
+
+@app.template_filter()
+def format_query_service(wiki: str) -> flask.Markup:
+    return (flask.Markup(r'<a href="') +
+            flask.Markup.escape(query_service_url(wiki)) +
+            flask.Markup(r'">') +
+            flask.Markup.escape(query_service_name(wiki)) +
+            flask.Markup(r'</a>'))
 
 
 def anonymous_session(wiki: str) -> mwapi.Session:

--- a/app.py
+++ b/app.py
@@ -451,6 +451,17 @@ def deny_frame(response: flask.Response) -> flask.Response:
     return response
 
 
+def statement_id_from_uri(uri: str, wiki: str) -> str:
+    for protocol in ['http', 'https']:
+        prefix = f'{protocol}://{wiki}/entity/statement/'
+        if uri.startswith(prefix):
+            break
+    else:
+        raise ValueError('URI {uri} does not belong to wiki {wiki}')
+    entity_id, _, guid = uri[len(prefix):].partition('-')
+    return f'{entity_id}${guid}'
+
+
 def entity_id_from_statement_id(statement_id: str) -> str:
     return statement_id.split('$', 1)[0].upper()
 

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ import werkzeug
 import yaml
 
 from converters import EntityIdConverter, PropertyIdConverter, \
-    RankConverter, WikiConverter
+    RankConverter, WikiConverter, WikiWithQueryServiceConverter
 from query_service import query_service_name, query_service_url
 import wbformat
 
@@ -49,6 +49,7 @@ app.url_map.converters['eid'] = EntityIdConverter
 app.url_map.converters['pid'] = PropertyIdConverter
 app.url_map.converters['rank'] = RankConverter
 app.url_map.converters['wiki'] = WikiConverter
+app.url_map.converters['wwqs'] = WikiWithQueryServiceConverter
 
 
 @app.template_global()

--- a/query_service.py
+++ b/query_service.py
@@ -1,0 +1,35 @@
+from typing import Collection
+from SPARQLWrapper import SPARQLWrapper, JSON  # type: ignore
+
+
+_query_services = {
+    'www.wikidata.org': (
+        'query.wikidata.org',
+        'Wikidata Query Service',
+    ),
+    'commons.wikimedia.org': (
+        'wcqs-beta.wmflabs.org',
+        'Wikimedia Commons Query Service',
+    ),
+}
+
+
+def query_wiki(wiki: str, query: str, user_agent: str) -> dict:
+    query_service = _query_services[wiki][0]
+    sparql = SPARQLWrapper(f'https://{query_service}/sparql', agent=user_agent)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    return sparql.query().convert()
+
+
+def wikis_with_query_service() -> Collection[str]:
+    return _query_services.keys()
+
+
+def query_service_name(wiki: str) -> str:
+    return _query_services[wiki][1]
+
+
+def query_service_url(wiki: str) -> str:
+    query_service = _query_services[wiki][0]
+    return f'https://{query_service}/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ mypy
 pyyaml
 requests
 requests_oauthlib
+SPARQLWrapper
 toolforge

--- a/templates/batch-query-collective.html
+++ b/templates/batch-query-collective.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% block main %}
+{% if not can_edit() %}
+<div class="alert alert-warning" role="alert">
+  You must <a href="{{ url_for('login') }}">log in</a> to make edits.
+</div>
+{% endif %}
+<form method="post">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
+  <div class="form-group">
+    <label for="query">
+      {{ wiki | format_query_service }} query,
+      selecting a <code>?statement</code> variable:
+    </label>
+    <textarea
+      class="form-control text-monospace"
+      id="query"
+      name="query"
+      placeholder="SELECT ?statement WHERE {&#xa;  # ...&#xa;}"
+      required
+      rows="10"
+      ></textarea>
+  </div>
+  <div class="form-group">
+    <label for="summary">Edit summary (optional):</label>
+    <input name="summary" type="text" id="summary" class="form-control">
+  </div>
+  {% if can_edit() %}
+  {% set disabled_attrs = '' %}
+  {% else %}
+  {% set disabled_attrs = 'disabled title="You must log in to make edits."' | safe %}
+  {% endif %}
+  <button
+    type="submit"
+    class="btn btn-primary"
+    formaction="{{ url_for('batch_query_set_rank', wiki=wiki, rank='preferred') }}"
+    {{ disabled_attrs }}>
+    Set to preferred rank
+  </button>
+  <button
+    type="submit"
+    class="btn btn-secondary"
+    formaction="{{ url_for('batch_query_set_rank', wiki=wiki, rank='normal') }}"
+    {{ disabled_attrs }}>
+    Set to normal rank
+  </button>
+  <button
+    type="submit"
+    class="btn btn-secondary"
+    formaction="{{ url_for('batch_query_set_rank', wiki=wiki, rank='deprecated') }}"
+    {{ disabled_attrs }}>
+    Set to deprecated rank
+  </button>
+  <button
+    type="submit"
+    class="btn btn-secondary"
+    formaction="{{ url_for('batch_query_increment_rank', wiki=wiki) }}"
+    {{ disabled_attrs }}>
+    Increment rank
+  </button>
+</form>
+{% endblock %}

--- a/test_app.py
+++ b/test_app.py
@@ -60,6 +60,18 @@ def test_format_value_escapes_html():
     assert ranker.format_value('test.wikidata.org', 'P95', value) == expected
 
 
+@pytest.mark.parametrize('uri, wiki, statement_id', [
+    ('http://www.wikidata.org/entity/statement/Q474472-dcf39f47-4275-6529-96f5-94808c2a81ac',  # noqa:E501
+     'www.wikidata.org',
+     'Q474472$dcf39f47-4275-6529-96f5-94808c2a81ac'),
+    ('https://commons.wikimedia.org/entity/statement/M80857538-e33a73d7-4567-a029-a6e6-14eb3bab8a65',  # noqa:E501
+     'commons.wikimedia.org',
+     'M80857538$e33a73d7-4567-a029-a6e6-14eb3bab8a65')
+])
+def test_statement_id_from_uri(uri: str, wiki: str, statement_id: str):
+    assert ranker.statement_id_from_uri(uri, wiki) == statement_id
+
+
 @pytest.mark.parametrize('statement_id, entity_id', [
     ('Q1$123', 'Q1'),
     ('p1$123', 'P1'),

--- a/test_app.py
+++ b/test_app.py
@@ -3,6 +3,9 @@ import pytest  # type: ignore
 from typing import Optional
 
 import app as ranker
+import query_service
+
+import test_query_service
 
 
 @pytest.fixture
@@ -94,6 +97,24 @@ P3$123
         'Q1': ['Q1$123', 'Q1$456'],
         'Q2': ['Q2$123', 'q2$456'],
         'P3': ['P3$123'],
+    }
+
+
+def test_query_statement_ids(monkeypatch):
+    def query_wiki(wiki: str, query: str, user_agent: str) -> dict:
+        assert wiki == test_query_service.test_wiki
+        assert query == test_query_service.test_query
+        return test_query_service.test_query_results
+
+    # monkeypatch original and imported function to support either import style
+    monkeypatch.setattr(ranker, 'query_wiki', query_wiki)
+    monkeypatch.setattr(query_service, 'query_wiki', query_wiki)
+
+    wiki = test_query_service.test_wiki
+    query = test_query_service.test_query
+    assert ranker.query_statement_ids(wiki, query) == {
+        'Q474472': ['Q474472$dcf39f47-4275-6529-96f5-94808c2a81ac'],
+        'Q3841190': ['Q3841190$dbcf6be8-41c0-5955-d618-2d06ab241344'],
     }
 
 

--- a/test_query_service.py
+++ b/test_query_service.py
@@ -1,0 +1,80 @@
+import pytest
+
+import query_service
+
+
+test_wiki = "www.wikidata.org"
+test_query = """
+SELECT ?item ?statement ?value WHERE {
+  VALUES (?item ?num) {
+    (wd:Q474472 1)
+    (wd:Q3841190 2)
+  }
+  ?item p:P18 ?statement.
+  ?statement ps:P18 ?value.
+}
+ORDER BY ?num
+""".strip()
+test_query_results = {
+    'head': {'vars': ['item', 'statement', 'value']},
+    'results': {'bindings': [
+        {
+            'item': {
+                'type': 'uri',
+                'value': 'http://www.wikidata.org/entity/Q474472'
+            },
+            'statement': {
+                'type': 'uri',
+                'value': 'http://www.wikidata.org/entity/statement/Q474472-dcf39f47-4275-6529-96f5-94808c2a81ac'  # noqa:E501
+            },
+            'value': {
+                'type': 'uri',
+                'value': 'http://commons.wikimedia.org/wiki/Special:FilePath/Earth%20as%20a%20%22Pale%20Blue%20Dot%22%20photographed%20by%20Voyager%201%20-%2019900606.tif'  # noqa:E501
+            }
+        },
+        {
+            'item': {
+                'type': 'uri',
+                'value': 'http://www.wikidata.org/entity/Q3841190'
+            },
+            'statement': {
+                'type': 'uri',
+                'value': 'http://www.wikidata.org/entity/statement/Q3841190-dbcf6be8-41c0-5955-d618-2d06ab241344'  # noqa:E501
+            },
+            'value': {
+                'type': 'uri',
+                'value': 'http://commons.wikimedia.org/wiki/Special:FilePath/Black%20hole%20-%20Messier%2087.jpg'  # noqa:E501
+            }
+        },
+    ]},
+}
+
+
+def test_query_wiki():
+    user_agent = ('ranker-test (https://ranker.toolforge.org/; '
+                  'ranker@lucaswerkmeister.de)')
+    results = query_service.query_wiki(test_wiki, test_query, user_agent)
+    assert results == test_query_results
+
+
+def test_wikis_with_query_service():
+    assert query_service.wikis_with_query_service() == {
+        'www.wikidata.org',
+        'commons.wikimedia.org',
+    }
+
+
+@pytest.mark.parametrize('wiki, expected', [
+    ('www.wikidata.org', 'Wikidata Query Service'),
+    ('commons.wikimedia.org', 'Wikimedia Commons Query Service'),
+])
+def test_query_service_name(wiki: str, expected: str):
+    assert query_service.query_service_name(wiki) == expected
+
+
+@pytest.mark.parametrize('wiki, expected', [
+    ('www.wikidata.org', 'https://query.wikidata.org/'),
+    ('commons.wikimedia.org', 'https://wcqs-beta.wmflabs.org/'),
+])
+def test_query_service_url(wiki: str, expected: str):
+    assert query_service.query_service_url(wiki) == expected


### PR DESCRIPTION
This version of batch mode is collective like the first one (#1), but takes the statement IDs from a query rather than a list.